### PR TITLE
Fixes: toast messages never hide

### DIFF
--- a/src/services/toast-service.ts
+++ b/src/services/toast-service.ts
@@ -112,7 +112,7 @@ export class ToastService {
 
         // Positioning toast at the top middle of the parent window
         const parentBounds = parent.getBounds();
-        const x = parentBounds.x + (parentBounds.width - 300) / 2;
+        const x = Math.round( parentBounds.x + (parentBounds.width - 300) / 2 );
         const y = parentBounds.y + 10;
         toastWindow.window.setPosition(x, y, false);
 


### PR DESCRIPTION
Probably only happens at certain resolution+margins combos.
I guess I was unlucky enough that my `y` ended up in a decimal.

Full error as follows:
```
\SFDX-Data-Move-Utility-Desktop-App\js\services\browser-console-service.js:55
LOG MESSAGE:ERROR: [\SFDX-Data-Move-Utility-Desktop-App\node_modules\@electron\remote\dist\src\main\server.js:465:71:465] 
Error: An unhadled exception occured in the renderer process: Uncaught Error: Could not call remote method 'setPosition'. Check that the method signature is correct. Underlying error: TypeError: Error processing argument at index 0, conversion failure from Underlying stack: TypeError: Error processing argument at index 0, conversion failure from 
    at \SFDX-Data-Move-Utility-Desktop-App\node_modules\@electron\remote\dist\src\main\server.js:465:71
    at IpcMainImpl.<anonymous> (\SFDX-Data-Move-Utility-Desktop-App\node_modules\@electron\remote\dist\src\main\server.js:323:27)
    at IpcMainImpl.emit (node:events:513:28)
    at EventEmitter.<anonymous> (node:electron/js2c/browser_init:2:82193)
    at EventEmitter.emit (node:events:513:28)
 (\SFDX-Data-Move-Utility-Desktop-App\js\electron-app\preload.js:21)
    at windowOnError (\SFDX-Data-Move-Utility-Desktop-App\js\electron-app\preload.js:14:39)
    at windowOnUnhandledRejection (\SFDX-Data-Move-Utility-Desktop-App\js\electron-app\preload.js:21:9).
consoleError @ \SFDX-Data-Move-Utility-Desktop-App\js\services\browser-console-service.js:55
_formatMessage @ \SFDX-Data-Move-Utility-Desktop-App\js\services\log-service.js:147
errorEx @ \SFDX-Data-Move-Utility-Desktop-App\js\services\log-service.js:100
windowOnError @ \SFDX-Data-Move-Utility-Desktop-App\js\electron-app\preload.js:14
windowOnUnhandledRejection @ \SFDX-Data-Move-Utility-Desktop-App\js\electron-app\preload.js:21
```